### PR TITLE
feat: 添加马来西亚国家银行警示查询和开发者社交平台支持

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -347,6 +347,28 @@ Instagram: https://instagram.com/username
 ...
 ```
 
+### 马来西亚国家银行消费者警示名单查询 (BNM Consumer Alert)
+
+```bash
+curl "http://localhost:8080/?bnm=公司名称"
+```
+
+返回示例：
+
+```json
+BNM FCA List（2 条）：
+[
+ {"name":"XX投资公司","website":"example.com"},
+ {"name":"YY金融服务","website":"example.net"}
+]
+```
+
+如果抓取失败，将返回：
+
+```plaintext
+🚨 BNM抓取失败
+```
+
 ---
 
 ## 开发指南

--- a/my_osint.c
+++ b/my_osint.c
@@ -18,7 +18,7 @@
  * ⚠️ 本工具仅供教育、研究与安全用途，请勿用于非法活动。
  *
  * @author  钟智强
- * @version v0.1.2
+ * @version v0.1.3
  */
 
 #include <stdio.h>

--- a/src/social.c
+++ b/src/social.c
@@ -168,7 +168,6 @@ int check_username(const SocialTarget *target, const char *username) {
 
 SocialTarget targets[] = {
     // Global / previously added
-    {"GitHub", "https://github.com/%s"},
     {"X", "https://x.com/%s"},
     {"Reddit", "https://www.reddit.com/user/%s"},
     {"Instagram", "https://www.instagram.com/%s"},
@@ -187,8 +186,22 @@ SocialTarget targets[] = {
     {"Steam", "https://steamcommunity.com/id/%s"},
     {"Vimeo", "https://vimeo.com/%s"},
     {"WordPress", "https://%s.wordpress.com"},
+
+    // DEV
     {"GitLab", "https://gitlab.com/%s"},
+    {"GitHub", "https://github.com/%s"},
+    {"Gitcode", "https://gitcode.com/%s"},
     {"Google Developers", "https://developers.google.com/profile/u/%s"},
+    {"Stack Overflow", "https://stackoverflow.com/users/%s"},
+    {"Rust Forum", "https://users.rust-lang.org/u/%s/summary"},
+    {"HackerNews", "https://news.ycombinator.com/user?id=%s"},
+    {"Eixir Forum", "https://elixirforum.com/u/%s/summary"},
+    {"Go Forum", "https://forum.golangbridge.org/u/%s/summary"},
+    {"FreeBSD Forum", "https://forums.freebsd.org/members/%s/"},
+    {"Dev.to", "https://dev.to/%s"},
+    {"Raspberry PI forum", "https://forums.raspberrypi.com/memberlist.php?mode=viewprofile&u=%s"},
+    {"Janus Meetecho Forum", "https://janus.discourse.group/u/%s/summary"},
+    {"Jitsi Forum", "https://forum.jitsi.group/u/%s/summary"},
 
     // NSFW 
     {"PornHub", "https://www.pornhub.com/users/%s"},
@@ -232,6 +245,7 @@ SocialTarget targets[] = {
     {"Viber", "https://viber.com/%s"},
     {"Skype", "https://join.skype.com/invite/%s"},
     {"Zoom", "https://zoom.us/profile/%s"},
+    {"Lowyat Forum", "https://forum.lowyat.net/index.php?showuser=%s"},
     {"Microsoft Teams", "https://teams.microsoft.com/profile/%s"},
     {"Slack", "https://%s.slack.com"},
     {"Mastodon", "https://mastodon.social/@%s"},


### PR DESCRIPTION
在Readme.md中添加马来西亚国家银行消费者警示名单查询接口文档
在social.c中新增多个开发者相关社交平台支持，并调整GitHub位置

#21